### PR TITLE
bugfix/accurics_remediation_18085332133005738 - Auto Generated Pull Request From Accurics

### DIFF
--- a/demo-terraform/aws/simple-ec2-with-s3-access/s3.tf
+++ b/demo-terraform/aws/simple-ec2-with-s3-access/s3.tf
@@ -1,28 +1,28 @@
 
 resource "random_string" "bucket_suffix" {
-    upper = false
-    special = false
-    length = 32
+  upper   = false
+  special = false
+  length  = 32
 }
 
 resource "aws_s3_bucket" "bucket" {
-    bucket = "${replace(local.user_mail,"@","-")}-${random_string.bucket_suffix.result}"
+  bucket = "${replace(local.user_mail, "@", "-")}-${random_string.bucket_suffix.result}"
 
-    tags = local.default_tags
+  tags = local.default_tags
 }
 
 resource "aws_s3_bucket_acl" "bucket" {
-    bucket = aws_s3_bucket.bucket.id
-    acl    = "private"
+  bucket = aws_s3_bucket.bucket.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_public_access_block" "bucket" {
-    bucket = aws_s3_bucket.bucket.id
+  bucket = aws_s3_bucket.bucket.id
 
-    block_public_acls   = false
-    block_public_policy = false
-    ignore_public_acls = false
-    restrict_public_buckets = false
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }
 
 # resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
@@ -34,3 +34,28 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
 #         }
 #     }
 # }
+
+resource "aws_s3_bucket_policy" "bucketpolicy" {
+  bucket = aws_s3_bucket.bucket.id
+
+  policy = <<POLICY
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                  "Sid": "bucket-restrict-access-to-users-or-roles",
+                  "Effect": "Allow",
+                  "Principal": [
+                    {
+                       "AWS": [
+                          "<aws_policy_role_arn>"
+                        ]
+                    }
+                  ],
+                  "Action": "s3:GetObject",
+                  "Resource": "arn:aws:s3:::bucket/*"
+              }
+            ]
+        }
+    POLICY
+}


### PR DESCRIPTION
Make sure to note Amazon S3 bucket access control lists (ACLs) that provide read, write, or full-access to 'Everyone'. It is recommended to provide access to S3 buckets to only authenticated users instead.